### PR TITLE
Fix MultiGrid index overflow

### DIFF
--- a/source/MultiGrid/MultiGrid.js
+++ b/source/MultiGrid/MultiGrid.js
@@ -642,7 +642,7 @@ class MultiGrid extends React.PureComponent {
         onScroll={enableFixedColumnScroll ? this._onScrollTop : undefined}
         ref={this._bottomLeftGridRef}
         rowCount={Math.max(0, rowCount - fixedRowCount) + additionalRowCount}
-        rowHeight={this._rowHeightBottomGrid}
+        rowHeight={this._rowHeightBottomLeftGrid}
         style={this._bottomLeftGridStyle}
         tabIndex={null}
         width={gridWidth}
@@ -788,6 +788,11 @@ class MultiGrid extends React.PureComponent {
     }
     return topRightGrid;
   }
+  
+  _rowHeightBottomLeftGrid = ({ index }) => {
+    const additionalRowCount = this.state.showHorizontalScrollbar ? 1 : 0;
+    return this._rowHeightBottomGrid({ index: index - additionalRowCount });
+  };
 
   _rowHeightBottomGrid = ({index}) => {
     const {fixedRowCount, rowCount, rowHeight} = this.props;


### PR DESCRIPTION
I found that _renderBottomLeftGrid and _renderBottomRightGrid rowCount are different。When they use the same function, because the length is different, it will cause overflow.

Thanks for contributing to react-virtualized!

**Before submitting a pull request,** please complete the following checklist:

- [ ] The existing test suites (`npm test`) all pass
- [ ] For any new features or bug fixes, both positive and negative test cases have been added
- [ ] For any new features, documentation has been added
- [ ] For any documentation changes, the text has been proofread and is clear to both experienced users and beginners.
- [ ] Format your code with [prettier](https://github.com/prettier/prettier) (`yarn run prettier`).
- [ ] Run the [Flow](https://flowtype.org/) typechecks (`yarn run typecheck`).

Here is a short checklist of additional things to keep in mind before submitting:

- Please make sure your pull request description makes it very clear what you're trying to accomplish. If it's a bug fix, please also provide a failing test case (if possible). In either case, please add additional unit test coverage for your changes. :)
- Be sure you have notifications setup so that you'll see my code review responses. (I may ask you to make some adjustments before merging.)
